### PR TITLE
update the imports: collections which is deprecated. Use collections.abc

### DIFF
--- a/2_step2_rebnn/rebnn.py
+++ b/2_step2_rebnn/rebnn.py
@@ -7,7 +7,7 @@ from timm.models.registry import register_model
 import math
 import torch
 from torch.nn import Parameter
-import collections
+import collections.abc as collections
 from torch.nn.modules.conv import _ConvNd
 from itertools import repeat
 


### PR DESCRIPTION
From https://stackoverflow.com/questions/59809785/i-get-a-attributeerror-module-collections-has-no-attribute-iterable-when-i, the collections module is deprecated. It returns an error due to that. This fixes it. Instead of:

```python
import collections
```

we should have: 

```python
import collections.abc as collections
```